### PR TITLE
feat: add operation messages via `RAISE NOTICE`

### DIFF
--- a/src/OperationHooksCorePlugin.ts
+++ b/src/OperationHooksCorePlugin.ts
@@ -27,10 +27,10 @@ export interface OperationHookEntry<T = any> {
 }
 
 export interface OperationHook {
-  before?: Array<OperationHookEntry>;
-  after?: Array<OperationHookEntry>;
-  error?: Array<OperationHookEntry<Error>>;
-  finally?: Array<OperationHookEntry<typeof FINALLY>>;
+  before?: OperationHookEntry[];
+  after?: OperationHookEntry[];
+  error?: OperationHookEntry<Error>[];
+  finally?: OperationHookEntry<typeof FINALLY>[];
 }
 
 export type OperationHookGenerator = (

--- a/src/OperationHooksPlugin.ts
+++ b/src/OperationHooksPlugin.ts
@@ -3,6 +3,7 @@ import OperationMessagesPlugin from "./OperationMessagesPlugin";
 import OperationMessagesMutationPayloadPlugin from "./OperationMessagesMutationPayloadPlugin";
 import OperationMessagesMutationPreFlightPlugin from "./OperationMessagesMutationPreFlightPlugin";
 import PgOperationHooksPlugin from "./PgOperationHooksPlugin";
+import PgNoticeMessagesPlugin from "./PgNoticeMessagesPlugin";
 import { makePluginByCombiningPlugins } from "graphile-utils";
 
 // Export types
@@ -13,6 +14,7 @@ const OperationHooksPlugin = makePluginByCombiningPlugins(
   OperationHooksCorePlugin,
   OperationMessagesPlugin,
   PgOperationHooksPlugin,
+  PgNoticeMessagesPlugin,
   OperationMessagesMutationPayloadPlugin,
   OperationMessagesMutationPreFlightPlugin
 );

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -20,9 +20,18 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
         resolveInfo: GraphQLResolveInfoWithMessages
       ) => (msg: any) => {
         // TODO
+        let json: any = null;
+        try {
+          json = JSON.parse(msg.detail);
+        } catch (e) {
+          console.dir(msg);
+          console.error("Failed to parse above GOPHK NOTICE from PostgreSQL");
+          console.error(e);
+        }
         resolveInfo.graphileMeta.messages.push({
           level: "info",
-          message: `NOTICE! ${msg.message}`,
+          message: msg.message,
+          ...json,
         });
       };
       let processNotice: ((msg: any) => void) | null = null;

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -1,0 +1,71 @@
+import { Plugin } from "graphile-build";
+import { OperationHookCallback, OperationHook } from "./OperationHooksPlugin";
+import { GraphQLResolveInfoWithMessages } from "./OperationMessagesPlugin";
+import * as assert from "assert";
+
+const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
+  builder
+) {
+  builder.hook("init", (_, build) => {
+    const hookGenerator: OperationHookCallback = fieldContext => {
+      if (!fieldContext.scope.isRootMutation) {
+        // We absolutely cannot support isRootQuery because root query resolvers
+        // run in parallel, all using the same PG client, so we wouldn't know
+        // which field a notice applied to. We need the Postgres client to only
+        // do this one thing.
+        return null;
+      }
+
+      const makeProcessNotice = (
+        resolveInfo: GraphQLResolveInfoWithMessages
+      ) => (msg: any) => {
+        // TODO
+        resolveInfo.graphileMeta.messages.push({
+          level: "info",
+          message: `NOTICE! ${msg.message}`,
+        });
+      };
+      let processNotice: ((msg: any) => void) | null = null;
+
+      const registerNotifyListener: OperationHookCallback = (
+        input,
+        _args,
+        context,
+        resolveInfo: GraphQLResolveInfoWithMessages
+      ) => {
+        assert(!processNotice, "processNotice should not be set yet!");
+        if (!context || !context.pgClient) {
+          // Not a PostGraphile dispatch (no client) - just return
+          return input;
+        }
+        processNotice = makeProcessNotice(resolveInfo);
+        context.pgClient.on("notice", processNotice);
+        return input;
+      };
+
+      const unregisterNotifyListener: OperationHookCallback = (
+        input,
+        _args,
+        context,
+        _resolveInfo: GraphQLResolveInfoWithMessages
+      ) => {
+        if (processNotice) {
+          context.pgClient.removeListener("notice", processNotice);
+        }
+        return input;
+      };
+
+      const hook: OperationHook = {
+        before: [{ priority: 100, callback: registerNotifyListener }],
+        finally: [{ priority: 500, callback: unregisterNotifyListener }],
+      };
+
+      return hook;
+    };
+
+    build.addOperationHook(hookGenerator);
+    return _;
+  });
+};
+
+export default PgNoticeMessagesPlugin;

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -19,6 +19,10 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
       const makeProcessNotice = (
         resolveInfo: GraphQLResolveInfoWithMessages
       ) => (msg: any) => {
+        if (msg.code !== "OPMSG") {
+          // We only care about OPMSG NOTICEs
+          return;
+        }
         // TODO
         let json: any = null;
         try {

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -23,7 +23,6 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
           // We only care about OPMSG NOTICEs
           return;
         }
-        // TODO
         let json: any = null;
         try {
           json = JSON.parse(msg.detail);
@@ -64,7 +63,7 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
         context,
         _resolveInfo: GraphQLResolveInfoWithMessages
       ) => {
-        if (context.pgClient["processNotice"]) {
+        if (context && context.pgClient && context.pgClient["processNotice"]) {
           context.pgClient.removeListener(
             "notice",
             context.pgClient["processNotice"]

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -7,7 +7,7 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
   builder
 ) {
   builder.hook("init", (_, build) => {
-    const hookGenerator: OperationHookCallback = fieldContext => {
+    const hookGenerator: OperationHookCallback = (fieldContext) => {
       if (!fieldContext.scope.isRootMutation) {
         // We absolutely cannot support isRootQuery because root query resolvers
         // run in parallel, all using the same PG client, so we wouldn't know

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -25,7 +25,7 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
           json = JSON.parse(msg.detail);
         } catch (e) {
           console.dir(msg);
-          console.error("Failed to parse above GOPHK NOTICE from PostgreSQL");
+          console.error("Failed to parse above OPMSG NOTICE from PostgreSQL");
           console.error(e);
         }
         resolveInfo.graphileMeta.messages.push({

--- a/src/__tests__/PgOperationHooksPlugin.test.ts
+++ b/src/__tests__/PgOperationHooksPlugin.test.ts
@@ -254,26 +254,52 @@ const equivalentFunctions = [
   ...argVariants(
     `\
 create function users_%OP%_%WHEN%(___) returns setof mutation_message as $$
-  select row(
+begin
+  raise debug '%', json_build_object(
+    'f', 'NOTICE',
+    'l', 'info',
+    'm', '' %MSG%,
+    'w', '%WHEN%',
+    'o', '%OP%',
+    'c', 'INFO1',
+    'p', array_to_json(ARRAY['name'])
+  )::text using errcode = 'GOPHK';
+
+  return next row(
     'info',
     '%WHEN% user %OP% mutation' %MSG%,
     ARRAY['name'],
     'INFO1'
   )::mutation_message;
-$$ language sql volatile set search_path from current;
+
+  return;
+end;
+$$ language plpgsql volatile set search_path from current;
 `,
     "users"
   ),
   ...argVariants(
     `\
 create function users_%OP%_%WHEN%(___) returns mutation_message[] as $$
-  select ARRAY[row(
+begin
+  raise debug '%', json_build_object(
+    'f', 'NOTICE',
+    'l', 'info',
+    'm', '' %MSG%,
+    'w', '%WHEN%',
+    'o', '%OP%',
+    'c', 'INFO1',
+    'p', array_to_json(ARRAY['name'])
+  )::text using errcode = 'GOPHK';
+
+  return ARRAY[row(
     'info',
     '%WHEN% user %OP% mutation' %MSG%,
     ARRAY['name'],
     'INFO1'
-  )::mutation_message]
-$$ language sql volatile set search_path from current;
+  )::mutation_message];
+end;
+$$ language plpgsql volatile set search_path from current;
 `,
     "users"
   ),
@@ -285,12 +311,26 @@ create function users_%OP%_%WHEN%(___) returns table(
   path text[],
   code text
 ) as $$
-  select 
-    'info'::text,
-    ('%WHEN% user %OP% mutation' %MSG%)::text,
-    ARRAY['name']::text[],
-    'INFO1'::text;
-$$ language sql volatile set search_path from current;
+begin
+  raise debug '%', json_build_object(
+    'f', 'NOTICE',
+    'l', 'info',
+    'm', '' %MSG%,
+    'w', '%WHEN%',
+    'o', '%OP%',
+    'c', 'INFO1',
+    'p', array_to_json(ARRAY['name'])
+  )::text using errcode = 'GOPHK';
+
+  level = 'info';
+  message = '%WHEN% user %OP% mutation' %MSG%;
+  path = ARRAY['name'];
+  code = 'INFO1';
+  return next;
+
+  return;
+end;
+$$ language plpgsql volatile set search_path from current;
 `,
     "users"
   ),
@@ -303,12 +343,24 @@ create function users_%OP%_%WHEN%(
   out path text[],
   out code text
 ) as $$
-  select 
-    'info'::text,
-    ('%WHEN% user %OP% mutation' %MSG%)::text,
-    ARRAY['name']::text[],
-    'INFO1'::text;
-$$ language sql volatile set search_path from current;
+begin
+  raise debug '%', json_build_object(
+    'f', 'NOTICE',
+    'l', 'info',
+    'm', '' %MSG%,
+    'w', '%WHEN%',
+    'o', '%OP%',
+    'c', 'INFO1',
+    'p', array_to_json(ARRAY['name'])
+  )::text using errcode = 'GOPHK';
+
+  level = 'info';
+  message = '%WHEN% user %OP% mutation' %MSG%;
+  path = ARRAY['name'];
+  code = 'INFO1';
+
+end;
+$$ language plpgsql volatile set search_path from current;
 `,
     "users",
     "in"

--- a/src/__tests__/PgOperationHooksPlugin.test.ts
+++ b/src/__tests__/PgOperationHooksPlugin.test.ts
@@ -266,6 +266,11 @@ begin
       'path', array_to_json(ARRAY['noticePath'])
     );
 
+  -- We should only catch OPMSG messages, so this one should be ignored.
+  raise notice 'DON''T CATCH THIS!'
+  using
+    errcode = 'NOTOP';
+
   return next row(
     'info',
     '%WHEN% user %OP% mutation' %MSG%,

--- a/src/__tests__/PgOperationHooksPlugin.test.ts
+++ b/src/__tests__/PgOperationHooksPlugin.test.ts
@@ -257,7 +257,7 @@ create function users_%OP%_%WHEN%(___) returns setof mutation_message as $$
 begin
   raise notice '%', 'NOTICE %WHEN% user %OP% mutation' %MSG%
   using
-    errcode = 'GOPHK',
+    errcode = 'OPMSG',
     detail = json_build_object(
       'level', 'info',
       'when', '%WHEN%',
@@ -285,7 +285,7 @@ create function users_%OP%_%WHEN%(___) returns mutation_message[] as $$
 begin
   raise notice '%', 'NOTICE %WHEN% user %OP% mutation' %MSG%
   using
-    errcode = 'GOPHK',
+    errcode = 'OPMSG',
     detail = json_build_object(
       'level', 'info',
       'when', '%WHEN%',
@@ -316,7 +316,7 @@ create function users_%OP%_%WHEN%(___) returns table(
 begin
   raise notice '%', 'NOTICE %WHEN% user %OP% mutation' %MSG%
   using
-    errcode = 'GOPHK',
+    errcode = 'OPMSG',
     detail = json_build_object(
       'level', 'info',
       'when', '%WHEN%',
@@ -349,7 +349,7 @@ create function users_%OP%_%WHEN%(
 begin
   raise notice '%', 'NOTICE %WHEN% user %OP% mutation' %MSG%
   using
-    errcode = 'GOPHK',
+    errcode = 'OPMSG',
     detail = json_build_object(
       'level', 'info',
       'when', '%WHEN%',


### PR DESCRIPTION
Fixes #12 (cc @demianuco)

PostGraphile will subscribe to `NOTICE` events from PostgreSQL during mutations, and any notice with error code `OPMSG` (operation message) will be added to the mutation payload `messages` field.

### Important:

- This feature only applies to mutations
- Any PL/pgSQL function may raise these notices
- Additional information can be added to the OPMSG by passing a JSON value to the `detail` field
- `RAISE NOTICE` may have message length limits; it's your responsibility to colour inside the lines
- Clients must be configured (via `client_min_messages`) to receive NOTICE messages; this is PostgreSQL's default configuration.
- If the server is configured (via `log_min_messages`) to log NOTICEs then, well, the NOTICEs will be logged; PostgreSQL's default configuration does not log NOTICE.

### Example:

```sql
raise notice 
  '2 + 2 is %, minus 1 that''s %; quick maths.',
  (2 + 2),
  (2 + 2 - 1)
using
  errcode = 'OPMSG',
  detail = json_build_object(
    'level', 'info',
    'path', array_to_json(ARRAY['noticePath']),
    'anything_else', 'can_go_here'
  )::text;
```