### PR TITLE
feat: Add `detail` field from messages to GraphQL schema

### DIFF
--- a/src/OperationMessagesMutationPayloadPlugin.ts
+++ b/src/OperationMessagesMutationPayloadPlugin.ts
@@ -53,6 +53,10 @@ const OperationMessagesMutationPayloadPlugin: Plugin = function OperationMessage
             description:
               "A list of path components to the location in the input at which this message was generated.",
           },
+          detail: {
+            type: GraphQLString,
+            description: "Additional data associated with the message",
+          },
         },
       },
       {
@@ -79,6 +83,10 @@ const OperationMessagesMutationPayloadPlugin: Plugin = function OperationMessage
             type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
             description:
               "A list of path components to the location in the input at which this message was generated.",
+          },
+          detail: {
+            type: GraphQLString,
+            description: "Additional data associated with the message",
           },
         },
       },

--- a/src/OperationMessagesPlugin.ts
+++ b/src/OperationMessagesPlugin.ts
@@ -8,6 +8,7 @@ interface Message {
   level: string;
   message: string;
   path?: string[];
+  detail?: string;
 }
 
 export interface GraphQLResolveInfoWithMessages

--- a/src/PgNoticeMessagesPlugin.ts
+++ b/src/PgNoticeMessagesPlugin.ts
@@ -24,8 +24,12 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
           return;
         }
         let json: any = null;
+        let jsonRest: any = null;
         try {
           json = JSON.parse(msg.detail);
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { level, message, path, ...jsonRestTmp } = json;
+          jsonRest = jsonRestTmp;
         } catch (e) {
           console.dir(msg);
           console.error("Failed to parse above OPMSG NOTICE from PostgreSQL");
@@ -35,6 +39,7 @@ const PgNoticeMessagesPlugin: Plugin = function PgNoticeMessagesPlugin(
           level: "info",
           message: msg.message,
           ...json,
+          detail: jsonRest ? JSON.stringify(jsonRest) : undefined,
         });
       };
 

--- a/src/__tests__/OperationMessagesPlugin.test.ts
+++ b/src/__tests__/OperationMessagesPlugin.test.ts
@@ -11,6 +11,7 @@ test("creates messages on meta", async () => {
         resolveInfo.graphileMeta.messages.push({
           level: "info",
           message: "All good",
+          detail: JSON.stringify({ foo: "bar" }),
         });
         return input;
       }
@@ -23,6 +24,7 @@ test("creates messages on meta", async () => {
   expect(resolveInfos[0].graphileMeta.messages).toMatchInlineSnapshot(`
 Array [
   Object {
+    "detail": "{\\"foo\\":\\"bar\\"}",
     "level": "info",
     "message": "All good",
   },
@@ -36,6 +38,7 @@ Object {
       "messages": Array [
         Object {
           "__typename": "OperationMessage",
+          "detail": "{\\"foo\\":\\"bar\\"}",
           "level": "info",
           "message": "All good",
         },
@@ -133,21 +136,25 @@ Object {
   "messages": Array [
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "info",
       "message": "Information from before",
     },
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "warn",
       "message": "Warning from before",
     },
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "info",
       "message": "Information from after",
     },
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "info",
       "message": "More information from after",
     },
@@ -198,11 +205,13 @@ Object {
   "messages": Array [
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "info",
       "message": "Information from before",
     },
     Object {
       "__typename": "OperationMessage",
+      "detail": null,
       "level": "warn",
       "message": "Warning from before",
     },

--- a/src/__tests__/PgOperationHooksPlugin.test.ts
+++ b/src/__tests__/PgOperationHooksPlugin.test.ts
@@ -523,6 +523,7 @@ describe("equivalent functions", () => {
         expect(resolveInfos[0].graphileMeta.messages).toEqual([
           {
             code: "INFO1",
+            detail: `{"when":"before","op":"${op}","code":"INFO1"}`,
             level: "info",
             message: `NOTICE before user ${op} mutation${preName}${preTupleName}${preOp}`,
             path: ["noticePath"],
@@ -537,6 +538,7 @@ describe("equivalent functions", () => {
           },
           {
             code: "INFO1",
+            detail: `{"when":"after","op":"${op}","code":"INFO1"}`,
             level: "info",
             message: `NOTICE after user ${op} mutation${postName}${postTupleName}${postOp}`,
             path: ["noticePath"],

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -64,6 +64,7 @@ export const EchoHiMutation = `
         __typename
         level
         message
+        detail
       }
       preflight
     }


### PR DESCRIPTION
## Description
Fixes #40.
In this PR:
- Added the `detail` field to the GraphQL Schema, which is expected to be a string, usually a JSON encoded object of additional data to be conveyed from the mutation to the client.
- When processing the messages, extract the details object from the mutation, extract hardcoded keys (`level`, `message` & `path`) and encode the rest into the new `detail` field.
- Amended existing tests to verify this functionality. Fixed existing tests to pass with this change.

(Discord msg: https://discord.com/channels/489127045289476126/498852330754801666/1187166222836576388)

## Performance impact
I believe there should be no significant impact unless an extraordinarily large `detail` field is passed.

## Security impact
One could argue that the `detail` field is confidential only to the server, but I personally find that unlikely since `level`, `message` and `path` are already shared with the client. If you disagree I believe we can find a more delicate solution:
- Global opt-in control to not create a vulnerability for existing users
- Per-mutation opt-in control
- Only pick up `detail.public` instead of everything under `detail`
Or anything else you'd find more appropriate. 

## Checklist
- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
